### PR TITLE
fix: standardize scale settings in Pivot Controls

### DIFF
--- a/src/world/DraggableAssetContainer.tsx
+++ b/src/world/DraggableAssetContainer.tsx
@@ -522,7 +522,8 @@ const DraggableAssetContainer = ({
           anchor={[0, 0, 0]}
           offset={pivotOffset}
           depthTest={false}
-          scale={1.25 * (scale >= 1 ? scale : 1)}
+          fixed
+          scale={150}
           activeAxes={[isActive, isActive, isActive]}
           visible={isActive}
           onDragEnd={handleObjectMove}

--- a/src/world/DraggableProductContainer.tsx
+++ b/src/world/DraggableProductContainer.tsx
@@ -567,7 +567,8 @@ const DraggableProductContainer = ({
           anchor={[0, 0, 0]}
           offset={pivotOffset}
           depthTest={false}
-          scale={1.25 * (scale >= 1 ? scale : 1)}
+          fixed
+          scale={150}
           activeAxes={[isActive, isActive, isActive]}
           visible={isActive}
           onDragEnd={handleObjectMove}


### PR DESCRIPTION
- Updated scale property to a fixed value of 150 in both DraggableAssetContainer and DraggableProductContainer components for consistency.
- Removed dynamic scaling logic to simplify the drag-and-drop functionality.